### PR TITLE
Use bash instead of POSIX sh

### DIFF
--- a/.aosbuild
+++ b/.aosbuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (c) 2013-2015 UnSX Team
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/build-bogosh
+++ b/build-bogosh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 source ./.aosbuild
 
 aos_compiler ${CC:-cc}

--- a/build-flytrap
+++ b/build-flytrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 source ./.aosbuild
 
 aos_compiler ${CC:-cc}


### PR DESCRIPTION
/usr/bin/env is used instead of strictly /bin/bash or /usr/bin/bash to ensure
compatibility with other *nixes and odd setups.

Fixes https://github.com/OrdinaryMagician/flytrap/issues/6